### PR TITLE
Add basic build+test CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push: { branches: [main] }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    strategy:
+      matrix:
+        os:
+          - label: Linux
+            runner: ubuntu-latest
+          - label: macOS
+            runner: macos-latest
+      fail-fast: false
+    name: Build & test (${{ matrix.os.label }})
+    runs-on: ${{ matrix.os.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: true }
+      - uses: actions/setup-python@v4
+      - run: pip install ".[raster,test]" -vv
+      - run: pytest -vv
+
+  min-reqs:
+    name: Build & test (minimum requirements)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: true }
+      - uses: actions/setup-python@v4
+        with: { python-version: "3.9" }
+      - run: pip install -c ci/min-reqs.txt ".[raster,test]" -vv
+      - run: pytest -vv
+
+  no-optional-deps:
+    name: Build & test (no optional dependencies)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: true }
+      - uses: actions/setup-python@v4
+      - run: pip install ".[test]" -vv
+      - run: pytest -vv

--- a/ci/min-reqs.txt
+++ b/ci/min-reqs.txt
@@ -1,0 +1,6 @@
+cmake==3.15.*
+numpy==1.20.*
+pytest==6.0.*
+pytest-cov==3.0.*
+python==3.9.*
+rasterio==1.0.*

--- a/ci/min-reqs.txt
+++ b/ci/min-reqs.txt
@@ -3,4 +3,4 @@ numpy==1.20.*
 pytest==6.0.*
 pytest-cov==3.0.*
 python==3.9.*
-rasterio==1.0.*
+rasterio==1.2.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = ["numpy>=1.20"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
-raster = ["rasterio>=1"]
+raster = ["rasterio>=1.2"]
 test = ["pytest>=6", "pytest-cov>=3"]
 
 [tool.black]


### PR DESCRIPTION
Add GitHub Actions workflows to install and test

* on Linux & macOS
* with the minimum supported versions of dependencies
* with & without optional dependencies (i.e. rasterio)

Bumps the minimum rasterio version to 1.2. Pip struggles to install older versions with Python 3.9 (our minimum Python version). Rasterio 1.2.0 has been around since Jan 2021, so I don't really have qualms about requiring at least that version.