### PR TITLE
Fix version tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os.runner }}
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0, submodules: true }
+        with: { fetch-tags: true, submodules: true }
       - uses: actions/setup-python@v4
       - run: pip install ".[raster,test]" -vv
       - run: pytest -vv
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0, submodules: true }
+        with: { fetch-tags: true, submodules: true }
       - uses: actions/setup-python@v4
         with: { python-version: "3.9" }
       - run: pip install -c ci/min-reqs.txt ".[raster,test]" -vv
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0, submodules: true }
+        with: { fetch-tags: true, submodules: true }
       - uses: actions/setup-python@v4
       - run: pip install ".[test]" -vv
       - run: pytest -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os.runner }}
     steps:
       - uses: actions/checkout@v4
-        with: { submodules: true }
+        with: { fetch-tags: true, submodules: true }
       - uses: actions/setup-python@v4
       - run: pip install ".[raster,test]" -vv
       - run: pytest -vv
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { submodules: true }
+        with: { fetch-tags: true, submodules: true }
       - uses: actions/setup-python@v4
         with: { python-version: "3.9" }
       - run: pip install -c ci/min-reqs.txt ".[raster,test]" -vv
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { submodules: true }
+        with: { fetch-tags: true, submodules: true }
       - uses: actions/setup-python@v4
       - run: pip install ".[test]" -vv
       - run: pytest -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os.runner }}
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-tags: true, submodules: true }
+        with: { fetch-depth: 0, submodules: true }
       - uses: actions/setup-python@v4
       - run: pip install ".[raster,test]" -vv
       - run: pytest -vv
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-tags: true, submodules: true }
+        with: { fetch-depth: 0, submodules: true }
       - uses: actions/setup-python@v4
         with: { python-version: "3.9" }
       - run: pip install -c ci/min-reqs.txt ".[raster,test]" -vv
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-tags: true, submodules: true }
+        with: { fetch-depth: 0, submodules: true }
       - uses: actions/setup-python@v4
       - run: pip install ".[test]" -vv
       - run: pytest -vv


### PR DESCRIPTION
Fix version tests in CI by fetching tags when checking out the repo so that setuptools_scm correctly infers the version syntax.