### PR TITLE
Specify minimum Python version for actions/setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0, submodules: true }
       - uses: actions/setup-python@v4
+        with: { python-version: ">=3.9" }
       - run: pip install ".[raster,test]" -vv
       - run: pytest -vv
 
@@ -45,5 +46,6 @@ jobs:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0, submodules: true }
       - uses: actions/setup-python@v4
+        with: { python-version: ">=3.9" }
       - run: pip install ".[test]" -vv
       - run: pytest -vv


### PR DESCRIPTION
If no version is specified, it doesn't install anything and just uses the system Python installation.

>[Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.](https://github.com/isce-framework/snaphu-py/actions/runs/7096568500/job/19315271192#step:3:10)