### PR TITLE
Add codecov reporting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         with: { python-version: ">=3.9" }
       - run: pip install ".[raster,test]" -vv
       - run: pytest -vv
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
   min-reqs:
     name: Build & test (minimum requirements)

--- a/src/snaphu/_unwrap.py
+++ b/src/snaphu/_unwrap.py
@@ -417,7 +417,7 @@ def unwrap(
     delete_scratch: bool = True,
     unw: OutputDataset,
     conncomp: OutputDataset,
-) -> tuple[OutputDataset, OutputDataset]: ...
+) -> tuple[OutputDataset, OutputDataset]: ...  # pragma: no cover
 
 
 # If `unw` and `conncomp` aren't specified, return the outputs as two NumPy arrays.
@@ -435,7 +435,7 @@ def unwrap(
     nproc: int = 1,
     scratchdir: str | os.PathLike[str] | None = None,
     delete_scratch: bool = True,
-) -> tuple[np.ndarray, np.ndarray]: ...
+) -> tuple[np.ndarray, np.ndarray]: ...  # pragma: no cover
 
 
 def unwrap(  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Add code coverage reporting via codecov. Coverage diffs are informational only -- drops in coverage don't cause checks to fail.