### PR TITLE
Add nodata attribute to Raster

### DIFF
--- a/src/snaphu/io/_raster.py
+++ b/src/snaphu/io/_raster.py
@@ -97,6 +97,7 @@ class Raster(InputDataset, OutputDataset, AbstractContextManager["Raster"]):
         driver: str | None = None,
         crs: str | Mapping[str, str] | rasterio.crs.CRS | None = None,
         transform: rasterio.transform.Affine | None = None,
+        nodata: float | None = None,
         *,
         like: Raster | None = None,
         **kwargs: Any,
@@ -135,6 +136,11 @@ class Raster(InputDataset, OutputDataset, AbstractContextManager["Raster"]):
             Affine transformation mapping the pixel space to geographic space. If None,
             the geotransform of `like` will be used, if available, otherwise the default
             transform will be used. Defaults to None.
+        nodata : float or None, optional
+            Defines the pixel value to be interpreted as not valid data. If None, the
+            nodata value of `like` will be used, if available, otherwise no nodata value
+            will be populated. Only real-valued nodata values are supported, even if the
+            raster data is complex-valued. Defaults to None.
         like : Raster or None, optional
             An optional reference raster. If not None, the new raster will be created
             with the same metadata (shape, data-type, driver, CRS/geotransform, etc) as
@@ -158,6 +164,8 @@ class Raster(InputDataset, OutputDataset, AbstractContextManager["Raster"]):
             kwargs["crs"] = crs
         if transform is not None:
             kwargs["transform"] = transform
+        if nodata is not None:
+            kwargs["nodata"] = nodata
 
         # Always create a single-band dataset, even if `like` was part of a multi-band
         # dataset.
@@ -232,6 +240,15 @@ class Raster(InputDataset, OutputDataset, AbstractContextManager["Raster"]):
         coordinate reference system.
         """
         return self.dataset.transform
+
+    @property
+    def nodata(self) -> float | None:
+        """
+        float or None : The raster's nodata value (may be unset).
+
+        The raster's nodata value, or None if no nodata value was set.
+        """
+        return self.dataset.nodatavals[self.band - 1]  # type: ignore[no-any-return]
 
     @property
     def closed(self) -> bool:

--- a/test/io/test_raster.py
+++ b/test/io/test_raster.py
@@ -14,6 +14,9 @@ from numpy.typing import DTypeLike
 
 import snaphu
 
+# Maximum value representable by 32-bit unsigned integer type.
+UINT32_MAX = np.iinfo(np.uint32).max
+
 
 def has_rasterio() -> bool:
     """Check if `rasterio` can be imported."""
@@ -27,6 +30,7 @@ def make_geotiff_raster(
     dtype: DTypeLike = np.int32,
     epsg: int = 4326,
     extents: tuple[float, float, float, float] = (0.0, 0.0, 1.0, 1.0),
+    nodata: float | None = None,
 ) -> Generator[snaphu.io.Raster, None, None]:
     """
     Make a dummy GeoTiff raster for testing.
@@ -47,6 +51,8 @@ def make_geotiff_raster(
         The geospatial extents of the raster image, in coordinates defined by the CRS
         represented by the `epsg` code, in the following order: West, South, East,
         North.
+    nodata : float or None, optional
+        Defines the pixel value to be interpreted as not valid data.
 
     Yields
     ------
@@ -65,6 +71,7 @@ def make_geotiff_raster(
         dtype=dtype,
         crs=crs,
         transform=transform,
+        nodata=nodata,
         driver="GTiff",
     ) as raster:
         yield raster
@@ -178,6 +185,23 @@ class TestRaster:
         height, width = 1024, 512
         transform = rasterio.transform.from_bounds(0.0, 0.0, 1.0, 1.0, width, height)
         assert geotiff_raster.transform == transform
+
+    @pytest.mark.parametrize(
+        ("dtype", "nodata"),
+        [
+            (np.int64, -999.0),
+            (np.uint32, UINT32_MAX),
+            (np.float64, 123.456),
+            (np.complex64, 0.0),
+            (np.float32, None),
+        ],
+    )
+    def test_nodata(self, dtype: DTypeLike, nodata: float | None):
+        with (
+            tempfile.NamedTemporaryFile(suffix=".tif") as file_,
+            make_geotiff_raster(file_.name, dtype=dtype, nodata=nodata) as raster,
+        ):
+            assert raster.nodata == nodata
 
     def test_open_closed(self):
         with make_temp_geotiff_raster() as raster:

--- a/test/io/test_raster.py
+++ b/test/io/test_raster.py
@@ -189,7 +189,7 @@ class TestRaster:
     @pytest.mark.parametrize(
         ("dtype", "nodata"),
         [
-            (np.int64, -999.0),
+            (np.int32, -999.0),
             (np.uint32, UINT32_MAX),
             (np.float64, 123.456),
             (np.complex64, 0.0),


### PR DESCRIPTION
Add the ability to set (when creating the Raster) and get the "nodata" value from Raster objects.

It seems most intuitive that the "nodata" value should have the same dtype as the Raster image data. However, due to underlying limitations in GDAL/rasterio[^1][^2], the nodata value must be a `float`, even if the raster is integer- or complex-valued.

[^1]: https://github.com/OSGeo/gdal/pull/808
[^2]: https://github.com/rasterio/rasterio/issues/1747