### PR TITLE
Add an option (enabled by default) to regrow connected components in tiled mode

### DIFF
--- a/src/snaphu/_unwrap.py
+++ b/src/snaphu/_unwrap.py
@@ -299,8 +299,10 @@ def regrow_conncomp_from_unw(
 
     # Write config parameters to file. The config file should have a descriptive name to
     # disambiguate it from the config file used for unwrapping.
-    config_file = Path(scratchdir) / "snaphu-regrow-conncomps.conf"
-    config_file.write_text(config)
+    _, config_file = mkstemp(
+        dir=scratchdir, prefix="snaphu-regrow-conncomps.config.", suffix=".txt"
+    )
+    Path(config_file).write_text(config)
 
     # Run SNAPHU in REGROWCONNCOMPS mode to generate new connected component labels.
     run_snaphu(config_file)
@@ -547,8 +549,8 @@ def unwrap(  # type: ignore[no-untyped-def]
             config += f"BYTEMASKFILE {tmp_mask}\n"
 
         # Write config parameters to file.
-        config_file = dir_ / "snaphu.conf"
-        config_file.write_text(config)
+        _, config_file = mkstemp(dir=dir_, prefix="snaphu.config.", suffix=".txt")
+        Path(config_file).write_text(config)
 
         # Run SNAPHU with the specified parameters.
         run_snaphu(config_file)


### PR DESCRIPTION
Add a new option `regrow_conncomps` to `unwrap()`. When enabled, it will re-run SNAPHU after the initial unwrapping step to "regrow" the connected components. This is useful in tiled unwrapping mode to compute a new set of connected components that are not delimited by the tile boundaries.

This behavior is typically desirable when unwrapping in tiled mode, and the regrowing step seems to be pretty fast + doesn't require much memory compared with unwrapping, so this option will be enabled by default.

Thanks to @scottstanie for showing me this option in SNAPHU and testing it out.

This PR also removes the `SnaphuConfig` class that was a bit over-engineered and wasn't easily extendable to support some of the more esoteric SNAPHU configurations/modes.