### PR TITLE
Add package metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["scikit-build-core"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "snaphu-py"
+name = "snaphu"
 authors = [
   { name = "Geoffrey Gunter", email = "geoffrey.m.gunter@jpl.nasa.gov" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,33 @@ requires = ["scikit-build-core"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "snaphu"
+name = "snaphu-py"
+authors = [
+  { name = "Geoffrey Gunter", email = "geoffrey.m.gunter@jpl.nasa.gov" },
+]
+description = "A simple Python wrapper for SNAPHU"
+readme = "README.md"
+keywords = [
+  "insar",
+  "phase-unwrapping",
+  "radar",
+  "remote-sensing",
+  "sar",
+  "synthetic-aperture-radar",
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "License :: Free for non-commercial use",
+  "License :: OSI Approved :: Apache Software License",
+  "License :: OSI Approved :: BSD License",
+  "License :: Other/Proprietary License",
+  "Operating System :: MacOS",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: Unix",
+  "Programming Language :: Python",
+  "Topic :: Scientific/Engineering",
+]
 requires-python = ">=3.9"
 dependencies = ["numpy>=1.20"]
 dynamic = ["version"]
@@ -11,6 +37,13 @@ dynamic = ["version"]
 [project.optional-dependencies]
 raster = ["rasterio>=1.2"]
 test = ["pytest>=6", "pytest-cov>=3"]
+
+[project.urls]
+"Bug Tracker" = "https://github.com/isce-framework/snaphu-py/issues"
+"Discussions" = "https://github.com/isce-framework/snaphu-py/discussions"
+"Homepage" = "https://github.com/isce-framework/snaphu-py"
+"Releases" = "https://github.com/isce-framework/snaphu-py/releases"
+"Source Code" = "https://github.com/isce-framework/snaphu-py"
 
 [tool.black]
 preview = true
@@ -88,6 +121,7 @@ known-first-party = ["snaphu"]
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.include = ["src/snaphu/_version.py"]
+wheel.license-files = ["LICENSE-*", "ext/snaphu/README"]
 
 [tool.setuptools_scm]
 write_to = "src/snaphu/_version.py"


### PR DESCRIPTION
Update the `pyproject.toml` file to include some basic package metadata (maintainers, URLs, classifiers, etc.)

Since the SNAPHU source is included as a Git submodule, it's likely to be included in source and binary distributions of snaphu-py, so I opted to include info about its license in the package metadata in addition to the license of the Python wrapper. I'm not sure whether that's appropriate or not, but it seemed to be the most prudent strategy in the face of uncertainty.