### PR TITLE
Automate upload of release source archives

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   create-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,25 @@
+name: CD
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, submodules: true }
+      - run: |
+          pipx run git-archive-all snaphu-py-${{ github.ref_name }}.zip
+          unzip -l snaphu-py-${{ github.ref_name }}.zip
+      - run: |
+          pipx run git-archive-all snaphu-py-${{ github.ref_name }}.tar.gz
+          tar -ztvf snaphu-py-${{ github.ref_name }}.tar.gz
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            snaphu-py-${{ github.ref_name }}.zip
+            snaphu-py-${{ github.ref_name }}.tar.gz
+          generate_release_notes: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,18 +10,20 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    env:
+      name_and_tag: snaphu-py-${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0, submodules: true }
       - run: |
-          pipx run git-archive-all snaphu-py-${{ github.ref_name }}.zip
-          unzip -l snaphu-py-${{ github.ref_name }}.zip
+          pipx run git-archive-all ${{ env.name_and_tag }}.zip
+          unzip -l ${{ env.name_and_tag }}.zip
       - run: |
-          pipx run git-archive-all snaphu-py-${{ github.ref_name }}.tar.gz
-          tar -ztvf snaphu-py-${{ github.ref_name }}.tar.gz
+          pipx run git-archive-all ${{ env.name_and_tag }}.tar.gz
+          tar -ztvf ${{ env.name_and_tag }}.tar.gz
       - uses: softprops/action-gh-release@v1
         with:
           files: |
-            snaphu-py-${{ github.ref_name }}.zip
-            snaphu-py-${{ github.ref_name }}.tar.gz
+            ${{ env.name_and_tag }}.zip
+            ${{ env.name_and_tag }}.tar.gz
           generate_release_notes: true


### PR DESCRIPTION
Add a GHA workflow which triggers whenever a versioned tag is pushed. It will automatically draft a release using https://github.com/softprops/action-gh-release. Git archives of the repo \*and all of its submodules\* are generated using https://github.com/Kentzo/git-archive-all and uploaded as release artifacts (in both .zip and .tar.gz format).

This is intended as a workaround for https://github.com/dear-github/dear-github/issues/214. The archives generated by GitHub on each release do not include submodules. This is inconvenient for distributing via package repositories like PyPI and conda-forge, which typically prefer to fetch source tarballs from GitHub.