### PR TITLE
Build wheels & sdists in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/snaphu-py
+      url: https://test.pypi.org/p/snaphu
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       - run: pytest -vv
 
   build-wheels:
+    if: github.event_name == 'push'
     strategy:
       matrix:
         os:
@@ -104,6 +105,7 @@ jobs:
           path: dist/*.tar.gz
 
   publish-to-testpypi:
+    if: github.event_name == 'push'
     name: Publish wheels and sdist to TestPyPI
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  artifact_prefix: snaphu-py
+
 jobs:
   build-and-test:
     strategy:
@@ -53,3 +56,68 @@ jobs:
         with: { python-version: ">=3.9" }
       - run: pip install ".[test]" -vv
       - run: pytest -vv
+
+  build-wheels:
+    strategy:
+      matrix:
+        os:
+          - label: Linux
+            runner: ubuntu-latest
+          - label: macOS
+            runner: macos-latest
+        arch:
+          - x86_64
+        include:
+          - os: { label: macOS, runner: macos-latest }
+            arch: arm64
+          - os: { label: Linux, runner: ubuntu-latest }
+            arch: i686
+      fail-fast: false
+    name: Build, lint, & test wheels (${{ matrix.os.label}} ${{ matrix.arch }})
+    runs-on: ${{ matrix.os.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, submodules: true }
+      - uses: pypa/cibuildwheel@v2.16.2
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_TEST_REQUIRES: pytest>=6 pytest-cov>=3
+          CIBW_TEST_COMMAND: pytest {package}/test
+          CIBW_TEST_SKIP: "*_arm64"
+      - run: pipx run check-wheel-contents ./wheelhouse/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.artifact_prefix }}-wheels-${{ matrix.os.runner }}-${{ matrix.arch }}
+          path: ./wheelhouse/*.whl
+
+  build-sdist:
+    name: Build & lint sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, submodules: true }
+      - run: pipx run build --sdist
+      - run: pipx run twine check --strict dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.artifact_prefix }}-sdist
+          path: dist/*.tar.gz
+
+  publish-to-testpypi:
+    name: Publish wheels and sdist to TestPyPI
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/snaphu-py
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ env.artifact_prefix }}-*
+          path: dist/
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,4 @@ wheel.license-files = ["LICENSE-*", "ext/snaphu/README"]
 
 [tool.setuptools_scm]
 write_to = "src/snaphu/_version.py"
+local_scheme = "no-local-version"


### PR DESCRIPTION
Add a CI job that runs on pull requests and pushes to main and executes the following steps:

* Build wheels for Linux & macOS x86_64, as well as Linux i686 and macOS ARM64 using [cibuildwheel](https://github.com/pypa/cibuildwheel)
* Run the test suite using generated wheels (except for macOS ARM64, which is cross-compiled)
* Lint wheels using [check-wheel-contents](https://github.com/jwodder/check-wheel-contents)
* Build an sdist and lint it using [`twine check`](https://twine.readthedocs.io/en/stable/#twine-check)
* Publish wheels & sdist to [TestPyPI](https://packaging.python.org/en/latest/guides/using-testpypi/)