### PR TITLE
Ignore contributions by bots in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
Configure the automatically-generated release notes to exclude contributions from @dependabot and @pre-commit-ci.

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options