### PR TITLE
Don't build 32-bit wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,6 @@ jobs:
         include:
           - os: { label: macOS, runner: macos-latest }
             arch: arm64
-          - os: { label: Linux, runner: ubuntu-latest }
-            arch: i686
       fail-fast: false
     name: Build, lint, & test wheels (${{ matrix.os.label}} ${{ matrix.arch }})
     runs-on: ${{ matrix.os.runner }}


### PR DESCRIPTION
32-bit Linux binaries seem to be much slower than 64-bit binaries on GHA runners. In recent workflow runs, testing the 64-bit Linux wheels took [~30-45 seconds each](https://github.com/isce-framework/snaphu-py/actions/runs/7574041340/job/20627549981), whereas testing the 32-bit wheels took [~195-270 seconds each](https://github.com/isce-framework/snaphu-py/actions/runs/7574041340/job/20627551723).

I'm not really sure what would account for this large runtime discrepancy, but don't have any immediate plans to investigate since I doubt there's any real demand for 32-bit binaries among SNAPHU users.

Building & testing 32-bit wheels is currently a major bottleneck in CI workflows that include this step. So let's just disable them in our builds.