### PR TITLE
Exclude some paths from Codecov scans

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,3 +6,10 @@ coverage:
     patch:
       default:
         informational: true
+
+ignore:
+  - docs/
+  - .github/
+  - .pre-commit-config.yaml
+  - pyproject.toml
+  - README.md


### PR DESCRIPTION
If a PR modifies only some subset of these paths, Codecov should not produce a report. This should hopefully reduce notification spam a little bit.

https://docs.codecov.com/docs/ignoring-paths