### PR TITLE
Expose `TILECOSTTHRESH` and `MINREGIONSIZE` parameters

### DIFF
--- a/src/snaphu/_unwrap.py
+++ b/src/snaphu/_unwrap.py
@@ -322,6 +322,8 @@ def unwrap(
     ntiles: tuple[int, int] = (1, 1),
     tile_overlap: int | tuple[int, int] = 0,
     nproc: int = 1,
+    tile_cost_thresh: int = 500,
+    min_region_size: int = 100,
     regrow_conncomps: bool = True,
     scratchdir: str | os.PathLike[str] | None = None,
     delete_scratch: bool = True,
@@ -343,6 +345,8 @@ def unwrap(
     ntiles: tuple[int, int] = (1, 1),
     tile_overlap: int | tuple[int, int] = 0,
     nproc: int = 1,
+    tile_cost_thresh: int = 500,
+    min_region_size: int = 100,
     regrow_conncomps: bool = True,
     scratchdir: str | os.PathLike[str] | None = None,
     delete_scratch: bool = True,
@@ -360,6 +364,8 @@ def unwrap(  # type: ignore[no-untyped-def]
     ntiles=(1, 1),
     tile_overlap=0,
     nproc=1,
+    tile_cost_thresh=500,
+    min_region_size=100,
     regrow_conncomps=True,
     scratchdir=None,
     delete_scratch=True,
@@ -418,6 +424,13 @@ def unwrap(  # type: ignore[no-untyped-def]
     nproc : int, optional
         Maximum number of child processes to spawn for parallel tile unwrapping. If
         `nproc` is less than 1, use all available processors. Defaults to 1.
+    tile_cost_thresh : int, optional
+        Cost threshold to use for determining boundaries of reliable regions
+        (dimensionless; scaled according to other cost constants). Larger cost threshold
+        implies smaller regions -- safer, but more expensive computationally. Defaults
+        to 500.
+    min_region_size : int, optional
+        Minimum size, in pixels, of a reliable region in tile mode. Defaults to 100.
     regrow_conncomps : bool, optional
         If True, the connected component labels will be re-computed using a single tile
         after first unwrapping with multiple tiles. This option is disregarded when
@@ -547,6 +560,8 @@ def unwrap(  # type: ignore[no-untyped-def]
             ROWOVRLP {tile_overlap[0]}
             COLOVRLP {tile_overlap[1]}
             NPROC {nproc}
+            TILECOSTTHRESH {tile_cost_thresh}
+            MINREGIONSIZE {min_region_size}
             """
         )
         if mask is not None:

--- a/test/test_unwrap.py
+++ b/test/test_unwrap.py
@@ -223,3 +223,18 @@ class TestUnwrap:
         )
         with pytest.raises(ValueError, match=pattern):
             snaphu.unwrap(igram, corr, nlooks=100.0, tile_overlap=(0, -1))
+
+    def test_bad_min_region_size(self):
+        shape = (256, 256)
+        igram = np.empty(shape, dtype=np.complex64)
+        corr = np.empty(shape, dtype=np.float32)
+
+        pattern = r"^minimum region size too large for given tile parameters$"
+        with pytest.raises(RuntimeError, match=pattern):
+            snaphu.unwrap(
+                igram,
+                corr,
+                nlooks=100.0,
+                ntiles=(2, 2),
+                min_region_size=1_000_000,
+            )


### PR DESCRIPTION
This PR adds `tile_cost_thresh` and `min_region_size` optional parameters to the `unwrap()` function. They map to the SNAPHU config parameters `TILECOSTTHRESH` and `MINREGIONSIZE`, respectively, and share the same default values as those parameters.

These options are potentially useful for controlling the size/number of connected components in tile mode. Even if connected component regrowing is enabled, the user may still wish to adjust these parameters in order improve the performance of the "secondary unwrapping" step. Decreasing the tile cost threshold and/or increasing the minimum region size may also help to avoid [unwrapping failures due to exceeding the max allowed number of secondary nodes/arcs](https://github.com/gmgunter/snaphu/blob/4b7ca6c08eec6b7e6a61d739237b8c182f0ce795/src/snaphu_tile.c#L2026-L2027).