### PR TITLE
Replace submodule SSH URL with HTTPS URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ext/snaphu"]
 	path = ext/snaphu
-	url = git@github.com:gmgunter/snaphu.git
+	url = https://github.com/gmgunter/snaphu.git


### PR DESCRIPTION
HTTPS links are more easily accessible for folks who haven't setup SSH keys with GitHub.