### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Use groups to combine multiple Dependabot updates into a single PR. This is a bit cleaner and sometimes required for actions that have interdependencies, like `upload-artifact`/`download-artifact`.

More details:

* https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
* https://learn.scientific-python.org/development/guides/gha-basic/#updating
* https://github.com/scientific-python/cookie/pull/348