### PR TITLE
Reduce code duplication in input validation checks

### DIFF
--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .io import InputDataset, OutputDataset
+
+__all__ = [
+    "check_bool_or_byte_dtype",
+    "check_complex_dtype",
+    "check_cost_mode",
+    "check_dataset_shapes",
+    "check_float_dtype",
+    "check_integer_dtype",
+]
+
+
+def check_dataset_shapes(
+    shape: tuple[int, ...], **datasets: InputDataset | OutputDataset
+) -> None:
+    """
+    Ensure that one or more datasets has a specified shape.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The expected shape of each dataset.
+    **datasets : dict, optional
+        Datasets whose shape must be equal to `shape`. The name of each keyword argument
+        is used to format the error message in case of a shape mismatch.
+
+    Raises
+    ------
+    ValueError
+        If any dataset had a different shape.
+    """
+    for name, arr in datasets.items():
+        if arr.shape != shape:
+            errmsg = (
+                f"shape mismatch: {name} dataset must have shape {shape}, instead got"
+                f" {name}.shape={arr.shape}"
+            )
+            raise ValueError(errmsg)
+
+
+def check_complex_dtype(**datasets: InputDataset | OutputDataset) -> None:
+    """
+    Ensure that one or more datasets is complex-valued.
+
+    Parameters
+    ----------
+    **datasets : dict, optional
+        Datasets whose datatype must be a complex floating-point type. The name of each
+        keyword argument is used to format the error message in case of a different
+        datatype.
+
+    Raises
+    ------
+    TypeError
+        If any dataset had a different datatype.
+    """
+    for name, arr in datasets.items():
+        if not np.issubdtype(arr.dtype, np.complexfloating):
+            errmsg = (
+                f"{name} dataset must be complex-valued, instead got dtype={arr.dtype}"
+            )
+            raise TypeError(errmsg)
+
+
+def check_float_dtype(**datasets: InputDataset | OutputDataset) -> None:
+    """
+    Ensure that one or more datasets is real-valued.
+
+    Parameters
+    ----------
+    **datasets : dict, optional
+        Datasets whose datatype must be a floating-point type. The name of each keyword
+        argument is used to format the error message in case of a different datatype.
+
+    Raises
+    ------
+    TypeError
+        If any dataset had a different datatype.
+    """
+    for name, arr in datasets.items():
+        if not np.issubdtype(arr.dtype, np.floating):
+            errmsg = (
+                f"{name} dataset must be real-valued, instead got dtype={arr.dtype}"
+            )
+            raise TypeError(errmsg)
+
+
+def check_integer_dtype(**datasets: InputDataset | OutputDataset) -> None:
+    """
+    Ensure that one or more datasets is integer-valued.
+
+    Parameters
+    ----------
+    **datasets : dict, optional
+        Datasets whose datatype must be a (signed or unsigned) integer type. The name of
+        each keyword argument is used to format the error message in case of a different
+        datatype.
+
+    Raises
+    ------
+    TypeError
+        If any dataset had a different datatype.
+    """
+    for name, arr in datasets.items():
+        if not np.issubdtype(arr.dtype, np.integer):
+            errmsg = (
+                f"{name} dataset must be integer-valued, instead got dtype={arr.dtype}"
+            )
+            raise TypeError(errmsg)
+
+
+def check_bool_or_byte_dtype(**datasets: InputDataset | OutputDataset) -> None:
+    """
+    Ensure that one or more datasets is boolean or 8-bit integer-valued.
+
+    Parameters
+    ----------
+    **datasets : dict, optional
+        Datasets whose datatype must be a boolean or 8-bit (signed or unsigned) integer
+        type. The name of each keyword argument is used to format the error message in
+        case of a different datatype.
+
+    Raises
+    ------
+    TypeError
+        If any dataset had a different datatype.
+    """
+    for name, arr in datasets.items():
+        dtype = arr.dtype
+        if (dtype != np.bool_) and (dtype != np.uint8) and (dtype != np.int8):
+            errmsg = (
+                f"{name} dataset must be a boolean or 8-bit integer-valued, instead got"
+                f" dtype={dtype}"
+            )
+            raise TypeError(errmsg)
+
+
+def check_cost_mode(cost: str) -> None:
+    """
+    Ensure that the input SNAPHU cost mode is valid and supported.
+
+    Parameters
+    ----------
+    cost : str
+        The cost mode.
+
+    Raises
+    ------
+    NotImplementedError
+        If the specified cost mode is not supported.
+    ValueError
+        If the specified cost mode is not a valid SNAPHU cost option.
+    """
+    cost_modes = {"defo", "smooth"}
+
+    if cost == "topo":
+        errmsg = (
+            "'topo' cost mode is not currently supported, cost must be one of"
+            f" {cost_modes}"
+        )
+        raise NotImplementedError(errmsg)
+
+    if cost not in cost_modes:
+        errmsg = f"cost mode must be in {cost_modes}, instead got {cost!r}"
+        raise ValueError(errmsg)

--- a/test/test_conncomp.py
+++ b/test/test_conncomp.py
@@ -215,8 +215,8 @@ class TestGrowConnComps:
         unw = np.empty(shape=(128, 128), dtype=np.float32)
         corr = np.empty(shape=(128, 129), dtype=np.float32)
         pattern = (
-            "^shape mismatch: corr and unw must have the same shape, instead got"
-            r" corr.shape=\(128, 129\) and unw.shape=\(128, 128\)$"
+            r"^shape mismatch: corr dataset must have shape \(128, 128\), instead got"
+            r" corr.shape=\(128, 129\)"
         )
         with pytest.raises(ValueError, match=pattern):
             snaphu.grow_conncomps(unw, corr, nlooks=100.0)
@@ -224,14 +224,14 @@ class TestGrowConnComps:
     def test_bad_unw_dtype(self):
         unw = np.empty(shape=(128, 128), dtype=np.complex64)
         corr = np.empty(unw.shape, dtype=np.float32)
-        pattern = r"^unw must be a real-valued array, instead got dtype=complex64$"
+        pattern = r"^unw dataset must be real-valued, instead got dtype=complex64$"
         with pytest.raises(TypeError, match=pattern):
             snaphu.grow_conncomps(unw, corr, nlooks=100.0)
 
     def test_bad_corr_dtype(self):
         unw = np.empty(shape=(128, 128), dtype=np.float32)
         corr = np.empty(unw.shape, dtype=np.complex64)
-        pattern = r"^corr must be a real-valued array, instead got dtype=complex64$"
+        pattern = r"^corr dataset must be real-valued, instead got dtype=complex64$"
         with pytest.raises(TypeError, match=pattern):
             snaphu.grow_conncomps(unw, corr, nlooks=100.0)
 

--- a/test/test_unwrap.py
+++ b/test/test_unwrap.py
@@ -177,8 +177,8 @@ class TestUnwrap:
         igram = np.empty(shape=(128, 128), dtype=np.complex64)
         corr = np.empty(shape=(128, 129), dtype=np.float32)
         pattern = (
-            "^shape mismatch: corr and igram must have the same shape, instead got"
-            r" corr.shape=\(128, 129\) and igram.shape=\(128, 128\)$"
+            r"^shape mismatch: corr dataset must have shape \(128, 128\), instead got"
+            r" corr.shape=\(128, 129\)"
         )
         with pytest.raises(ValueError, match=pattern):
             snaphu.unwrap(igram, corr, nlooks=100.0)
@@ -187,7 +187,7 @@ class TestUnwrap:
         shape = (128, 128)
         igram = np.empty(shape, dtype=np.float64)
         corr = np.empty(shape, dtype=np.float32)
-        pattern = r"^igram must be a complex-valued array, instead got dtype=float64$"
+        pattern = r"^igram dataset must be complex-valued, instead got dtype=float64$"
         with pytest.raises(TypeError, match=pattern):
             snaphu.unwrap(igram, corr, nlooks=100.0)
 
@@ -195,7 +195,7 @@ class TestUnwrap:
         shape = (128, 128)
         igram = np.empty(shape, dtype=np.complex64)
         corr = np.empty(shape, dtype=np.complex64)
-        pattern = r"^corr must be a real-valued array, instead got dtype=complex64$"
+        pattern = r"^corr dataset must be real-valued, instead got dtype=complex64$"
         with pytest.raises(TypeError, match=pattern):
             snaphu.unwrap(igram, corr, nlooks=100.0)
 


### PR DESCRIPTION
Refactor input validation checks to reduce copy/paste and improve coverage. The should be no functional changes (except for slightly different error messages).