### PR TITLE
Improve Pylance support for Raster

### DIFF
--- a/src/snaphu/io/__init__.py
+++ b/src/snaphu/io/__init__.py
@@ -1,32 +1,18 @@
-from typing import Any
-
 from ._dataset import InputDataset, OutputDataset
 
 __all__ = [
     "InputDataset",
     "OutputDataset",
+    "Raster",
 ]
 
 
-def __getattr__(name: str) -> Any:
-    if name == "Raster":
-        # This module depends on `rasterio` so load it lazily to avoid an ImportError
-        # for users that don't need `Raster`.
-        from ._raster import Raster
-
-        return Raster
-
-    if name in __all__:
-        return globals()[name]
-
-    errmsg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(errmsg)
-
-
-def __dir__() -> list[str]:
-    try:
-        from ._raster import Raster
-    except ModuleNotFoundError:
-        return __all__
-    else:
-        return sorted([*__all__, "Raster"])
+# The `_raster` submodule depends on the `rasterio` package (an optional dependency).
+# Failing to import the module should be non-fatal, but we shouldn't expose its contents
+# in that case.
+# Note: This implementation is preferred over PEP 562-style `__getattr__` and `__dir__`
+# functions due to better compatibility with Pylance.
+try:
+    from ._raster import Raster
+except ModuleNotFoundError:
+    __all__.remove("Raster")

--- a/test/io/test_raster.py
+++ b/test/io/test_raster.py
@@ -97,6 +97,20 @@ def make_temp_geotiff_raster() -> Generator[snaphu.io.Raster, None, None]:
         yield raster
 
 
+def test_public_raster():
+    if has_rasterio():
+        assert "Raster" in dir(snaphu.io)
+    else:
+        assert "Raster" not in dir(snaphu.io)
+
+
+@pytest.mark.skipif(has_rasterio(), reason="")
+def test_bad_raster_import():
+    pattern = r"^cannot import name 'Raster' from 'snaphu.io'"
+    with pytest.raises(ImportError, match=pattern):
+        from snaphu.io import Raster
+
+
 @pytest.mark.skipif(not has_rasterio(), reason="requires rasterio package")
 class TestRaster:
     @pytest.fixture(scope="class")


### PR DESCRIPTION
@scottstanie pointed out that [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) was failing to find the definition of `snaphu.io.Raster`, as evidenced by VSCode mouseover tooltips implicitly treating the type as equivalent to `Any`.

![image](https://github.com/isce-framework/snaphu-py/assets/12984092/6d4c9bc2-3d49-4b7f-aba5-1db351782f07)

This is presumably a consequence of the heterodox way in which `Raster` is exported (using [PEP 562](https://peps.python.org/pep-0562/)-style module-level `__getattr__()` and `__dir__()` functions).

This PR tries to update the way that `Raster` is exported to improve compatibility with Pylance while still preserving the same runtime behavior. In particular:

1. If the `rasterio` package is missing, importing `snaphu.io` should not fail. `Raster` should not be a member of `snaphu.io` in this case. Attempting to import `snaphu.io.Raster` should raise an `ImportError`.
2. If the `rasterio` package *is* available, `snaphu.io.Raster` should be a valid type and `'Raster'` should be contained in `dir(snaphu.io)`.

Since Pylance statically analyzes the code, the trick is to initially add `Raster` to `snaphu.io.__all__` and then dynamically remove it from the list if it could not be imported at runtime.