### PR TITLE
Improve Pylance support for `Raster`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     rev: "v1.10.0"
     hooks:
       - id: mypy
+        exclude: snaphu/io/__init__\.py$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.4.4"

--- a/src/snaphu/io/__init__.pyi
+++ b/src/snaphu/io/__init__.pyi
@@ -1,0 +1,8 @@
+from ._dataset import InputDataset, OutputDataset
+from ._raster import Raster
+
+__all__ = [
+    "InputDataset",
+    "OutputDataset",
+    "Raster",
+]

--- a/test/io/test_raster.py
+++ b/test/io/test_raster.py
@@ -97,6 +97,19 @@ def make_temp_geotiff_raster() -> Generator[snaphu.io.Raster, None, None]:
         yield raster
 
 
+def test_public_raster():
+    if has_rasterio():
+        assert "Raster" in dir(snaphu.io)
+    else:
+        assert "Raster" not in dir(snaphu.io)
+
+
+@pytest.mark.skipif(has_rasterio(), reason="")
+def test_bad_raster_import():
+    with pytest.raises(ImportError, match=r"^No module named 'rasterio'$"):
+        from snaphu.io import Raster  # noqa: F401
+
+
 @pytest.mark.skipif(not has_rasterio(), reason="requires rasterio package")
 class TestRaster:
     @pytest.fixture(scope="class")


### PR DESCRIPTION
This PR supersedes #66. Refer to that PR for background.

The approach in the previous PR satisfied Pylance but ran into issues with Mypy. This PR instead tries to resolve the issue by including a typing stub (.pyi) file that exposes the Raster class for static analysis tools like Pylance and Mypy without affecting the runtime behavior.

The new approach seems to work well, except Mypy now complains about the new stub file conflicting with the existing .py file:

```
src/snaphu/io/__init__.pyi: error: Duplicate module named "snaphu.io" (also at "src/snaphu/io/__init__.py")
```

This seems to be related to the way that pre-commit passes arguments to Mypy. When running Mypy on a directory containing both .py and .pyi files, it runs fine. But when passing individual .py and .pyi files with identical module names as separate arguments to Mypy (as pre-commit does) it raises the above error.

Since this issue is largely related to the particular way that pre-commit runs Mypy, I think a reasonable bandaid is to simply exclude the conflicting .py file from the pre-commit hook.

Closes #66