### PR TITLE
Expose KPARDPSI and KPERPDPSI options

### DIFF
--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -5,6 +5,7 @@ import numpy as np
 from .io import InputDataset, OutputDataset
 
 __all__ = [
+    "check_2d_shapes",
     "check_bool_or_byte_dtype",
     "check_complex_dtype",
     "check_cost_mode",
@@ -12,6 +13,33 @@ __all__ = [
     "check_float_dtype",
     "check_integer_dtype",
 ]
+
+
+def check_2d_shapes(**shapes: tuple[int, ...]) -> None:
+    """
+    Ensure that the input tuples are valid 2-D shapes.
+
+    Parameters
+    ----------
+    **shapes : dict, optional
+        Input tuples to check for validity. Inputs must be pairs of positive integers.
+        The name of each keyword argument is used to format the error message in case of
+        an invalid input.
+
+    Raises
+    ------
+    ValueError
+        If an input had invalid length or contained invalid (negative or zero) values.
+    """
+    for name, shape in shapes.items():
+        if len(shape) != 2:
+            errmsg = f"{name} must be a pair of ints, instead got {name}={shape}"
+            raise ValueError(errmsg)
+        if not all(n >= 1 for n in shape):
+            errmsg = (
+                f"{name} may not contain negative or zero values, got {name}={shape}"
+            )
+            raise ValueError(errmsg)
 
 
 def check_dataset_shapes(

--- a/test/test_unwrap.py
+++ b/test/test_unwrap.py
@@ -223,6 +223,25 @@ class TestUnwrap:
         with pytest.raises(ValueError, match=pattern):
             snaphu.unwrap(igram, corr, nlooks=100.0, init="asdf")
 
+    def test_bad_phase_grad_window(self):
+        shape = (128, 128)
+        igram = np.empty(shape, dtype=np.complex64)
+        corr = np.empty(shape, dtype=np.float32)
+
+        pattern = (
+            r"^phase_grad_window must be a pair of ints, instead got"
+            r" phase_grad_window=\(1, 2, 3\)$"
+        )
+        with pytest.raises(ValueError, match=pattern):
+            snaphu.unwrap(igram, corr, nlooks=100.0, phase_grad_window=(1, 2, 3))  # type: ignore[arg-type]
+
+        pattern = (
+            r"^phase_grad_window may not contain negative or zero values, got"
+            r" phase_grad_window=\(1, 0\)$"
+        )
+        with pytest.raises(ValueError, match=pattern):
+            snaphu.unwrap(igram, corr, nlooks=100.0, phase_grad_window=(1, 0))
+
     def test_bad_ntiles(self):
         shape = (128, 128)
         igram = np.empty(shape, dtype=np.complex64)


### PR DESCRIPTION
`KPARDPSI` and `KPERPDPSI` are SNAPHU config options that control the size of the sliding window used to estimate the local phase gradient when computing the cost functions. @vbrancat pointed out that it's sometimes useful to modify these parameters.

The two options are exposed as a pair of ints via a new keyword-only parameter `phase_grad_window` in the Python interface.

I'm open to feedback regarding the renaming -- up until now, parameter names have been mostly straightforward translations of the corresponding SNAPHU configuration options, but "KPARDPSI" and "KPERPDPSI" seem like especially poor public variable names to me.