### PR TITLE
Replace memmap usage with direct file I/O

### DIFF
--- a/src/snaphu/_unwrap.py
+++ b/src/snaphu/_unwrap.py
@@ -19,7 +19,7 @@ from ._check import (
 )
 from ._conncomp import regrow_conncomp_from_unw
 from ._snaphu import run_snaphu
-from ._util import copy_blockwise, nan_to_zero, scratch_directory
+from ._util import nan_to_zero, read_from_file, scratch_directory, write_to_file
 from .io import InputDataset, OutputDataset
 
 __all__ = [
@@ -331,40 +331,34 @@ def unwrap(  # type: ignore[no-untyped-def]
         # Create a raw binary file in the scratch directory for the interferogram and
         # copy the input data to it. (`mkstemp` is used to avoid data races in case the
         # same scratch directory was used for multiple SNAPHU processes.)
-        _, tmp_igram = mkstemp(dir=dir_, prefix="snaphu.igram.", suffix=".c8")
-        tmp_igram_mmap = np.memmap(tmp_igram, dtype=np.complex64, shape=igram.shape)
-        copy_blockwise(igram, tmp_igram_mmap, transform=nan_to_zero)
-        tmp_igram_mmap.flush()
+        _, igram_file = mkstemp(dir=dir_, prefix="snaphu.igram.", suffix=".c8")
+        write_to_file(igram, igram_file, transform=nan_to_zero, dtype=np.complex64)
 
         # Copy the input coherence data to a raw binary file in the scratch directory.
-        _, tmp_corr = mkstemp(dir=dir_, prefix="snaphu.corr.", suffix=".f4")
-        tmp_corr_mmap = np.memmap(tmp_corr, dtype=np.float32, shape=corr.shape)
-        copy_blockwise(corr, tmp_corr_mmap, transform=nan_to_zero)
-        tmp_corr_mmap.flush()
+        _, corr_file = mkstemp(dir=dir_, prefix="snaphu.corr.", suffix=".f4")
+        write_to_file(corr, corr_file, transform=nan_to_zero, dtype=np.float32)
 
         # If a mask was provided, copy the mask data to a raw binary file in the scratch
         # directory.
         if mask is None:
-            tmp_mask = None
+            mask_file = None
         else:
-            _, tmp_mask = mkstemp(dir=dir_, prefix="snaphu.mask.", suffix=".u1")
-            tmp_mask_mmap = np.memmap(tmp_mask, dtype=np.bool_, shape=mask.shape)
-            copy_blockwise(mask, tmp_mask_mmap)
-            tmp_mask_mmap.flush()
+            _, mask_file = mkstemp(dir=dir_, prefix="snaphu.mask.", suffix=".u1")
+            write_to_file(mask, mask_file, dtype=np.bool_)
 
         # Create files in the scratch directory for SNAPHU outputs.
-        _, tmp_unw = mkstemp(dir=dir_, prefix="snaphu.unw.", suffix=".f4")
-        _, tmp_conncomp = mkstemp(dir=dir_, prefix="snaphu.conncomp.", suffix=".u4")
+        _, unw_file = mkstemp(dir=dir_, prefix="snaphu.unw.", suffix=".f4")
+        _, conncomp_file = mkstemp(dir=dir_, prefix="snaphu.conncomp.", suffix=".u4")
 
         config = textwrap.dedent(
             f"""\
-            INFILE {tmp_igram}
+            INFILE {igram_file}
             INFILEFORMAT COMPLEX_DATA
-            CORRFILE {tmp_corr}
+            CORRFILE {corr_file}
             CORRFILEFORMAT FLOAT_DATA
-            OUTFILE {tmp_unw}
+            OUTFILE {unw_file}
             OUTFILEFORMAT FLOAT_DATA
-            CONNCOMPFILE {tmp_conncomp}
+            CONNCOMPFILE {conncomp_file}
             CONNCOMPOUTTYPE UINT
             LINELENGTH {igram.shape[1]}
             NCORRLOOKS {nlooks}
@@ -383,7 +377,7 @@ def unwrap(  # type: ignore[no-untyped-def]
             """
         )
         if mask is not None:
-            config += f"BYTEMASKFILE {tmp_mask}\n"
+            config += f"BYTEMASKFILE {mask_file}\n"
 
         # Optionally re-optimize the unwrapped phase using a single tile after
         # unwrapping in tiled mode. This step should have no effect when running in
@@ -409,33 +403,27 @@ def unwrap(  # type: ignore[no-untyped-def]
             # for example, to detect zero-magnitude pixels which should be masked out
             # (i.e. connected component label set to 0). So compute the interferogram
             # magnitude and pass it as a separate input file.
-            _, tmp_mag = mkstemp(dir=dir_, prefix="snaphu.mag.", suffix=".f4")
-            tmp_mag_mmap = np.memmap(tmp_mag, dtype=np.float32, shape=igram.shape)
-            copy_blockwise(tmp_igram_mmap, tmp_mag_mmap, transform=np.abs)
-            tmp_mag_mmap.flush()
+            _, mag_file = mkstemp(dir=dir_, prefix="snaphu.mag.", suffix=".f4")
+            write_to_file(igram, mag_file, transform=np.abs, dtype=np.float32)
 
             # Re-run SNAPHU to compute new connected components from the unwrapped phase
             # as though in single-tile mode, overwriting the original connected
             # components file.
             regrow_conncomp_from_unw(
-                unw_file=tmp_unw,
-                corr_file=tmp_corr,
-                conncomp_file=tmp_conncomp,
+                unw_file=unw_file,
+                corr_file=corr_file,
+                conncomp_file=conncomp_file,
                 line_length=igram.shape[1],
                 nlooks=nlooks,
                 cost=cost,
-                mag_file=tmp_mag,
-                mask_file=tmp_mask,
+                mag_file=mag_file,
+                mask_file=mask_file,
                 min_conncomp_frac=min_conncomp_frac,
                 scratchdir=dir_,
             )
 
-        # Get the output unwrapped phase data.
-        tmp_unw_mmap = np.memmap(tmp_unw, dtype=np.float32, shape=unw.shape)
-        copy_blockwise(tmp_unw_mmap, unw)
-
-        # Get the output connected component labels.
-        tmp_cc_mmap = np.memmap(tmp_conncomp, dtype=np.uint32, shape=conncomp.shape)
-        copy_blockwise(tmp_cc_mmap, conncomp)
+        # Get the output unwrapped phase and connected component labels.
+        read_from_file(unw, unw_file, dtype=np.float32)
+        read_from_file(conncomp, conncomp_file, dtype=np.uint32)
 
     return unw, conncomp

--- a/src/snaphu/_util.py
+++ b/src/snaphu/_util.py
@@ -1,190 +1,173 @@
 from __future__ import annotations
 
-import itertools
+import io
 import os
 import shutil
-from collections.abc import Callable, Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkdtemp
 
 import numpy as np
-from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike, DTypeLike
 
 from .io import InputDataset, OutputDataset
 
 __all__ = [
-    "BlockIterator",
-    "ceil_divide",
-    "copy_blockwise",
     "nan_to_zero",
+    "read_from_file",
     "scratch_directory",
+    "write_to_file",
 ]
 
 
-def as_tuple_of_int(ints: int | Iterable[int]) -> tuple[int, ...]:
+def slices(start: int, stop: int, step: int = 1) -> Iterator[slice]:
     """
-    Convert the input to a tuple of ints.
+    Iterate over slices spanning a range.
+
+    Yield successive non-overlapping slices of length `step` that span the half-open
+    interval from `start` to `stop` (excluding `stop` itself).
 
     Parameters
     ----------
-    ints : int or iterable of int
-        One or more integers.
+    start : int
+        The start of the range.
+    stop : int
+        The end of the range.
+    step : int, optional
+        The maximum length of each slice. The final slice may be smaller. Must be >= 1.
+        Defaults to 1.
 
-    Returns
-    -------
-    out : tuple of int
-        Tuple containing the input(s).
+    Yields
+    ------
+    slice
+        A slice representing a sub-range of the specified range.
     """
-    try:
-        return (int(ints),)  # type: ignore[arg-type]
-    except TypeError:
-        return tuple([int(i) for i in ints])  # type: ignore[union-attr]
-
-
-def ceil_divide(n: ArrayLike, d: ArrayLike) -> np.ndarray:
-    """
-    Return the smallest integer greater than or equal to the quotient of the inputs.
-
-    Computes integer division of dividend `n` by divisor `d`, rounding up instead of
-    truncating.
-
-    Parameters
-    ----------
-    n : array_like
-        The numerator.
-    d : array_like
-        The denominator.
-
-    Returns
-    -------
-    q : numpy.ndarray
-        The quotient, rounded up to the next integer.
-    """
-    n = np.asanyarray(n)
-    d = np.asanyarray(d)
-    return (n + d - np.sign(d)) // d
-
-
-@dataclass(frozen=True)
-class BlockIterator(Iterable[tuple[slice, ...]]):
-    """
-    An iterable over chunks of an N-dimensional array.
-
-    `BlockIterator` represents a partitioning of a multidimensional array into
-    regularly-sized non-overlapping blocks. Each block is represented by an index
-    expression (i.e. a tuple of `slice` objects) that can be used to access the
-    corresponding block of data from the partitioned array. The full set of blocks spans
-    the entire array.
-
-    Iterating over a `BlockIterator` object yields each block in unspecified order.
-    """
-
-    shape: tuple[int, ...]
-    """tuple of int : The shape of the array to be partitioned into blocks."""
-    chunks: tuple[int, ...]
-    """
-    tuple of int : The shape of a typical block. The last block along each axis may be
-    smaller.
-    """
-
-    def __init__(self, shape: int | Iterable[int], chunks: int | Iterable[int]):
-        """
-        Construct a new `BlockIterator` object.
-
-        Parameters
-        ----------
-        shape : int or iterable of int
-            The shape of the array to be partitioned into blocks. Each dimension must be
-            > 0.
-        chunks : int or iterable of int
-            The shape of a typical block. Must be the same length as `shape`. Each chunk
-            dimension must be > 0.
-        """
-        # Normalize `shape` and `chunks` into tuples of ints.
-        shape = as_tuple_of_int(shape)
-        chunks = as_tuple_of_int(chunks)
-
-        if len(chunks) != len(shape):
-            errmsg = (
-                "size mismatch: shape and chunks must have the same number of elements,"
-                f" instead got len(shape) != len(chunks) ({len(shape)} !="
-                f" {len(chunks)})"
-            )
-            raise ValueError(errmsg)
-
-        if not all(n > 0 for n in shape):
-            errmsg = f"shape elements must all be > 0, instead got {shape}"
-            raise ValueError(errmsg)
-        if any(n <= 0 for n in chunks):
-            errmsg = f"chunk elements must all be > 0, instead got {chunks}"
-            raise ValueError(errmsg)
-
-        # XXX Workaround for `frozen=True`.
-        object.__setattr__(self, "shape", shape)
-        object.__setattr__(self, "chunks", chunks)
-
-    def __iter__(self) -> Iterator[tuple[slice, ...]]:
-        """
-        Iterate over blocks in unspecified order.
-
-        Yields
-        ------
-        block : tuple of slice
-            A tuple of slices that can be used to access the corresponding block of data
-            from an array.
-        """
-        # Number of blocks along each array axis.
-        nblocks = ceil_divide(self.shape, self.chunks)
-
-        # Iterate over blocks.
-        for block_ind in itertools.product(*[range(n) for n in nblocks]):
-            # Get the lower & upper index bounds for the current block.
-            start = np.multiply(block_ind, self.chunks)
-            stop = np.minimum(start + self.chunks, self.shape)
-
-            # Yield a tuple of slice objects.
-            yield tuple(itertools.starmap(slice, zip(start, stop)))
-
-
-def copy_blockwise(
-    src: InputDataset,
-    dst: OutputDataset,
-    chunks: tuple[int, int] = (1024, 1024),
-    *,
-    transform: Callable[[ArrayLike], np.ndarray] | None = None,
-) -> None:
-    """
-    Copy the contents of `src` to `dst` block-by-block.
-
-    Parameters
-    ----------
-    src : snaphu.io.InputDataset
-        Source dataset.
-    dst : snaphu.io.OutputDataset
-        Destination dataset.
-    chunks : (int, int), optional
-        Block dimensions. Defaults to (1024, 1024).
-    transform : callable or None, optional
-        An optional function object that is applied to each input block of data from
-        `src` to produce the corresponding output block in `dst`. The function should
-        take a single array_like parameter and return a NumPy array. If None, no
-        transform is applied. Defaults to None.
-    """
-    shape = src.shape
-    if dst.shape != shape:
-        errmsg = (
-            "shape mismatch: src and dst must have the same shape, instead got"
-            f" {src.shape=} and {dst.shape=}"
-        )
+    if step < 1:
+        errmsg = f"step must be >= 1, instead got {step}"
         raise ValueError(errmsg)
 
-    for block in BlockIterator(shape, chunks):
-        if transform is None:
-            dst[block] = src[block]
-        else:
-            dst[block] = transform(src[block])
+    while start < stop:
+        end = min(start + step, stop)
+        yield slice(start, end)
+        start = end
+
+
+def write_to_file(
+    dataset: InputDataset,
+    file: str | os.PathLike[str] | io.IOBase,
+    *,
+    batchsize: int = 512,
+    transform: Callable[[ArrayLike], np.ndarray] = np.asanyarray,
+    dtype: DTypeLike | None = None,
+) -> None:
+    """
+    Write the dataset contents to a file.
+
+    The data is written in batches by slicing along the leading axis of the dataset in
+    order to avoid holding the entire dataset in memory at once.
+
+    Parameters
+    ----------
+    dataset : snaphu.io.InputDataset
+        The input dataset.
+    file : path-like or file-like
+        An open file object or valid file path. If the path to an existing file is
+        provided, the file will be overwritten.
+    batchsize : int, optional
+        The maximum length of each batch of data along the leading axis of `dataset`.
+        Defaults to 512.
+    transform : callable, optional
+        An function that is applied to each batch of data from `dataset` before writing
+        it to the file. The function should take a single array_like parameter and
+        return a NumPy array. Defaults to `numpy.asanyarray`.
+    dtype : data-type or None, optional
+        The datatype used to store the dataset contents in the file. Each batch of data
+        will be cast to this datatype before writing it to the file. If None, uses the
+        datatype of the input dataset. Defaults to None.
+    """
+    # If the `file` argument was a path, open the file for writing in binary mode and
+    # truncate the file if it exists.
+    if isinstance(file, (str, os.PathLike)):
+        with Path(file).open("w+b") as file:
+            write_to_file(
+                dataset,
+                file,
+                batchsize=batchsize,
+                dtype=dtype,
+                transform=transform,
+            )
+        return
+
+    # The input dataset must be at least 1-D.
+    if dataset.ndim < 1:
+        errmsg = f"dataset must be at least 1-D, instead got {dataset.ndim=}"
+        raise ValueError(errmsg)
+
+    # If `dtype` was not specified, default to the dataset's dtype.
+    if dtype is None:
+        dtype = dataset.dtype
+
+    # Iterate over batches of data by slicing the dataset along its leading axis.
+    for slice_ in slices(0, dataset.shape[0], batchsize):
+        # Transform the batch of data as necessary and write it to the file.
+        arr = transform(dataset[slice_]).astype(dtype, copy=False)
+        arr.tofile(file)
+
+
+def read_from_file(
+    dataset: OutputDataset,
+    file: str | os.PathLike[str] | io.IOBase,
+    *,
+    batchsize: int = 512,
+    dtype: DTypeLike | None = None,
+) -> None:
+    """
+    Populate the dataset contents by reading from a file.
+
+    The data is read in batches by slicing along the leading axis of the dataset in
+    order to avoid holding the entire dataset in memory at once.
+
+    The file size must not be less than the size of the dataset contents.
+
+    Parameters
+    ----------
+    dataset : snaphu.io.OutputDataset
+        The output dataset.
+    file : path-like or file-like
+        An open file object or valid path to an existing file.
+    batchsize : int, optional
+        The maximum length of each batch of data along the leading axis of `dataset`.
+        Defaults to 512.
+    dtype : data-type or None, optional
+        The datatype of the contents of the file. If None, the file contents will be
+        assumed to have the same datatype as the output dataset (including byte order).
+        Defaults to None.
+    """
+    # If the `file` argument was a path, open the file for reading in binary mode.
+    if isinstance(file, (str, os.PathLike)):
+        with Path(file).open("rb") as f:
+            read_from_file(dataset, f, batchsize=batchsize, dtype=dtype)
+        return
+
+    # The input dataset must be at least 1-D.
+    if dataset.ndim < 1:
+        errmsg = f"dataset must be at least 1-D, instead got {dataset.ndim=}"
+        raise ValueError(errmsg)
+
+    # If `dtype` was not specified, default to the dataset's dtype.
+    if dtype is None:
+        dtype = dataset.dtype
+
+    # Iterate over batches of data by slicing the dataset along its leading axis.
+    n = dataset.shape[0]
+    for slice_ in slices(0, n, batchsize):
+        # Infer the shape and size of the corresponding slice of the dataset.
+        shape = (slice_.stop - slice_.start,) + dataset.shape[1:]
+        size = np.prod(shape)
+
+        # Read a batch of data from the file.
+        dataset[slice_] = np.fromfile(file, dtype=dtype, count=size).reshape(shape)
 
 
 def nan_to_zero(arr: ArrayLike) -> np.ndarray:

--- a/src/snaphu/_util.py
+++ b/src/snaphu/_util.py
@@ -17,6 +17,7 @@ __all__ = [
     "nan_to_zero",
     "read_from_file",
     "scratch_directory",
+    "slices",
     "write_to_file",
 ]
 
@@ -83,8 +84,8 @@ def write_to_file(
         return a NumPy array. Defaults to `numpy.asanyarray`.
     dtype : data-type or None, optional
         The datatype used to store the dataset contents in the file. Each batch of data
-        will be cast to this datatype before writing it to the file. If None, uses the
-        datatype of the input dataset. Defaults to None.
+        will be cast to this datatype before writing it to the file. If None, the
+        datatype is inferred from the data after applying `transform`. Defaults to None.
     """
     # If the `file` argument was a path, open the file for writing in binary mode and
     # truncate the file if it exists.
@@ -104,14 +105,12 @@ def write_to_file(
         errmsg = f"dataset must be at least 1-D, instead got {dataset.ndim=}"
         raise ValueError(errmsg)
 
-    # If `dtype` was not specified, default to the dataset's dtype.
-    if dtype is None:
-        dtype = dataset.dtype
-
     # Iterate over batches of data by slicing the dataset along its leading axis.
     for slice_ in slices(0, dataset.shape[0], batchsize):
         # Transform the batch of data as necessary and write it to the file.
-        arr = transform(dataset[slice_]).astype(dtype, copy=False)
+        arr = transform(dataset[slice_])
+        if dtype is not None:
+            arr = arr.astype(dtype, copy=False)
         arr.tofile(file)
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -2,9 +2,118 @@ import shutil
 import tempfile
 from pathlib import Path
 
+import numpy as np
 import pytest
+from numpy.typing import DTypeLike
 
-from snaphu._util import scratch_directory
+from snaphu._util import read_from_file, scratch_directory, slices, write_to_file
+
+
+class TestSlices:
+    def test_is_iterator(self):
+        s = slices(0, 100, 10)
+        next(s)
+
+    def test_start_stop(self):
+        s = list(slices(0, 3))
+        assert s == [slice(0, 1, None), slice(1, 2, None), slice(2, 3, None)]
+
+    def test_start_stop_step(self):
+        s = list(slices(10, 20, 4))
+        assert s == [slice(10, 14, None), slice(14, 18, None), slice(18, 20, None)]
+
+    @pytest.mark.parametrize("step", [0, -1])
+    def test_bad_step(self, step: int):
+        errmsg = f"^step must be >= 1, instead got {step}$"
+        with pytest.raises(ValueError, match=errmsg):
+            list(slices(0, 100, step))
+
+    def test_empty(self):
+        s1 = list(slices(100, 100))
+        assert s1 == []
+        s2 = list(slices(101, 100))
+        assert s2 == []
+
+
+class TestWriteToFile:
+    def test_filelike(self):
+        dtype = np.int32
+        shape = (100, 20)
+        in_arr = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
+        with tempfile.TemporaryFile() as file:
+            write_to_file(in_arr, file, batchsize=10)
+            file.seek(0)
+            out_arr = np.fromfile(file, dtype=dtype).reshape(shape)
+        np.testing.assert_array_equal(in_arr, out_arr)
+
+    def test_pathlike(self):
+        dtype = np.int32
+        shape = (100, 20)
+        in_arr = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
+        with tempfile.TemporaryDirectory() as dir_:
+            file = Path(dir_, "test.i4")
+            write_to_file(in_arr, file, batchsize=10)
+            out_arr = np.fromfile(file, dtype=dtype).reshape(shape)
+        np.testing.assert_array_equal(in_arr, out_arr)
+
+    @pytest.mark.parametrize("dtype", ["<i4", ">i4"])
+    def test_endian(self, dtype: DTypeLike):
+        in_arr = np.arange(1000, dtype=np.int32)
+        with tempfile.TemporaryFile() as file:
+            write_to_file(in_arr, file, dtype=dtype)
+            file.seek(0)
+            out_arr = np.fromfile(file, dtype=dtype)
+        np.testing.assert_array_equal(in_arr, out_arr)
+
+    def test_transform(self):
+        phase = np.linspace(-np.pi, np.pi, num=1001)
+        in_arr = np.exp(1j * phase)
+        with tempfile.TemporaryFile() as file:
+            write_to_file(in_arr, file, transform=np.angle)
+            file.seek(0)
+            out_arr = np.fromfile(file, dtype=np.float64)
+        np.testing.assert_allclose(out_arr, phase, atol=1e-6)
+
+    def test_0d(self):
+        in_arr = np.int32(0)
+        with tempfile.TemporaryFile() as file:
+            errmsg = r"^dataset must be at least 1-D, instead got dataset\.ndim=0$"
+            with pytest.raises(ValueError, match=errmsg):
+                write_to_file(in_arr, file)
+
+
+class TestReadFromFile:
+    def test_filelike(self):
+        dtype = np.int32
+        shape = (101, 20)
+        in_arr = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
+        out_arr = np.empty_like(in_arr)
+        with tempfile.TemporaryFile() as file:
+            in_arr.tofile(file)
+            file.seek(0)
+            read_from_file(out_arr, file, batchsize=10)
+        np.testing.assert_array_equal(in_arr, out_arr)
+
+    def test_pathlike(self):
+        dtype = np.int32
+        shape = (101, 20)
+        in_arr = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
+        out_arr = np.empty_like(in_arr)
+        with tempfile.TemporaryDirectory() as dir_:
+            file = Path(dir_, "test.i4")
+            in_arr.tofile(file)
+            read_from_file(out_arr, file, batchsize=10)
+        np.testing.assert_array_equal(in_arr, out_arr)
+
+    def test_0d(self):
+        in_arr = np.int32(123)
+        out_arr = np.int32(0)
+        with tempfile.TemporaryFile() as file:
+            in_arr.tofile(file)
+            file.seek(0)
+            errmsg = r"^dataset must be at least 1-D, instead got dataset\.ndim=0$"
+            with pytest.raises(ValueError, match=errmsg):
+                read_from_file(out_arr, file)
 
 
 class TestScratchDirectory:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,103 +1,10 @@
-import itertools
 import shutil
 import tempfile
-from collections.abc import Iterable
 from pathlib import Path
 
-import numpy as np
 import pytest
 
-from snaphu._util import BlockIterator, ceil_divide, scratch_directory
-
-
-class TestCeilDivide:
-    def test_positive(self):
-        assert ceil_divide(3, 2) == 2
-        assert ceil_divide(4, 2) == 2
-        assert ceil_divide(1, 1_000_000) == 1
-
-    def test_negative(self):
-        assert ceil_divide(-3, 2) == -1
-        assert ceil_divide(3, -2) == -1
-        assert ceil_divide(-3, -2) == 2
-
-        assert ceil_divide(-4, 2) == -2
-        assert ceil_divide(4, -2) == -2
-        assert ceil_divide(-4, -2) == 2
-
-    def test_zero(self):
-        assert ceil_divide(0, 1) == 0
-        assert ceil_divide(-0, 1) == 0
-
-    def test_divide_by_zero(self):
-        with pytest.warns(RuntimeWarning) as record:
-            ceil_divide(1, 0)
-
-        assert len(record) == 1
-        warning = record[0].message.args[0]
-        assert "divide by zero encountered" in warning
-
-    def test_arraylike(self):
-        result = ceil_divide([1, 2, 3, 4, 5], 2)
-        expected = [1, 1, 2, 2, 3]
-        np.testing.assert_array_equal(result, expected)
-
-
-class TestBlockIterator:
-    @pytest.fixture
-    def blocks2d(self) -> BlockIterator:
-        return BlockIterator(shape=(100, 101), chunks=(25, 34))
-
-    def test_is_iterable(self, blocks2d: BlockIterator):
-        assert isinstance(blocks2d, Iterable)
-
-    def test_attrs(self, blocks2d: BlockIterator):
-        assert blocks2d.shape == (100, 101)
-        assert blocks2d.chunks == (25, 34)
-
-    def test_nblocks(self, blocks2d: BlockIterator):
-        nblocks = len(list(blocks2d))
-        assert nblocks == 12
-
-    def test_iter(self, blocks2d: BlockIterator):
-        arr = np.zeros(blocks2d.shape, dtype=np.int32)
-        for block in blocks2d:
-            arr[block] += 1
-        np.testing.assert_array_equal(arr, 1)
-
-    def test_blocks1d(self):
-        blocks = BlockIterator(shape=99, chunks=25)
-        assert blocks.shape == (99,)
-        assert blocks.chunks == (25,)
-
-        starts = [0, 25, 50, 75]
-        stops = [25, 50, 75, 99]
-        for block, start, stop in itertools.zip_longest(blocks, starts, stops):
-            (slice_,) = block
-            assert slice_.start == start
-            assert slice_.stop == stop
-            assert slice_.step is None
-
-    def test_shape_chunks_mismatch(self):
-        pattern = (
-            "^size mismatch: shape and chunks must have the same number of elements,"
-            r" instead got len\(shape\) != len\(chunks\) \(2 != 3\)$"
-        )
-        with pytest.raises(ValueError, match=pattern):
-            BlockIterator(shape=(300, 400), chunks=(3, 4, 5))
-
-    def test_bad_shape(self):
-        pattern = r"^shape elements must all be > 0, instead got \(100, -1\)$"
-        with pytest.raises(ValueError, match=pattern):
-            BlockIterator(shape=(100, -1), chunks=(10, 10))
-
-    def test_bad_chunks(self):
-        pattern = r"^chunk elements must all be > 0, instead got \(10, -1\)$"
-        with pytest.raises(ValueError, match=pattern):
-            BlockIterator(shape=(100, 100), chunks=(10, -1))
-
-    def test_repr(self, blocks2d: BlockIterator):
-        assert repr(blocks2d) == "BlockIterator(shape=(100, 101), chunks=(25, 34))"
+from snaphu._util import scratch_directory
 
 
 class TestScratchDirectory:


### PR DESCRIPTION
Previously, the library made extensive usage of memory-mapping to copy the contents of inputs & outputs to & from binary files for compatibility with the SNAPHU executable. Memory-mapping is convenient for copying 2-D blocks of data to ensure that we don't run out of available memory while copying entire large datasets.

However, there seems to be no interface in NumPy or in Python's `mmap` library to ensure that the memory-mapped file is safely closed (at least prior to Python 3.13 -- see https://github.com/python/cpython/issues/78502). This may cause issues when unwrapping a large series of interferograms in a single process, potentially leading to the number of open file descriptors exceeding the system's resource limits.

In this update, we replace usage of `numpy.memmap` with direct file I/O. In order to avoid undue complexity (as well as potential performance issues due to buffered file access) we now read/write contiguous batches of data that span all columns of the input/output datasets, rather than operating on 2-D sub-blocks of data. This new approach gives full control over when files are opened and closed, in order to avoid leaking resources.

~~TODO: unit tests~~