### PR TITLE
Upload CI artifacts on "push" triggers only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
       - run: |
           pip install check-wheel-contents
           check-wheel-contents ./wheelhouse/*.whl
-      - uses: actions/upload-artifact@v4
+      - if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.artifact_prefix }}-wheels-${{ matrix.runner }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
@@ -107,7 +108,8 @@ jobs:
         with: { fetch-depth: 0, submodules: true }
       - run: pipx run build --sdist
       - run: pipx run twine check --strict dist/*
-      - uses: actions/upload-artifact@v4
+      - if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.artifact_prefix }}-sdist
           path: dist/*.tar.gz


### PR DESCRIPTION
Uploaded CI artifacts (including wheels and sdists) are currently used for publishing to PyPI (or TestPyPI). The `publish-to-pypi` and `publish-to-testpypi` jobs are only triggered by "push" events -- otherwise these uploaded artifacts simply go unused.

A significant portion of CI runs are triggered by PRs, which don't need these artifacts. In order to avoid wasting resources, let's upload CI artifacts only on "push" events.

We'll still continue to run the jobs which generate these artifacts for testing purposes. The artifacts will just be discarded when the job finishes.