### PR TITLE
Fix `io.Raster.__array__()` for NumPy>=2

### DIFF
--- a/src/snaphu/io/_raster.py
+++ b/src/snaphu/io/_raster.py
@@ -267,8 +267,15 @@ class Raster(InputDataset, OutputDataset, AbstractContextManager["Raster"]):
     def __exit__(self, exc_type, exc_value, traceback):  # type: ignore[no-untyped-def]
         self.close()
 
-    def __array__(self) -> np.ndarray:
-        return self.dataset.read(self.band)
+    def __array__(
+        self, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
+        if not copy and (copy is not None):
+            errmsg = "unable to avoid copy while creating an array as requested"
+            raise ValueError(errmsg)
+
+        data = self.dataset.read(self.band)
+        return data if (dtype is None) else data.astype(dtype)
 
     def _window_from_slices(
         self, key: slice | tuple[slice, ...]


### PR DESCRIPTION
The new NumPy major version makes some interface-breaking changes to the `__array__` protocol: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword

The `__array__` method now must take `dtype=None` and `copy=None` parameters. Adding these parameters does not affect backwards-compatibility with older NumPy versions.

`copy=False` should always fail for `Raster`, since converting a `Raster` to an array always involves creating a new array (rather than creating a view of an existing array).

I would've preferred to make both parameters keyword-only, but the `dtype` parameter seems to be passed positionally by `np.asarray`, at least with my current NumPy version (v2.1.1), so it seems best to just allow both parameters to be positional.