### PR TITLE
Ensure scratch directory is safely deleted

### DIFF
--- a/src/snaphu/_util.py
+++ b/src/snaphu/_util.py
@@ -265,7 +265,8 @@ def scratch_directory(
         else:
             scratchdir.mkdir(parents=True)
 
-    yield scratchdir
-
-    if delete:
-        shutil.rmtree(scratchdir)
+    try:
+        yield scratchdir
+    finally:
+        if delete:
+            shutil.rmtree(scratchdir)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -200,8 +200,8 @@ class TestScratchDirectory:
         # is raised within the `with` block.
         try:
             with scratch_directory() as scratchdir:
-                raise RuntimeError
-        except:
+                raise RuntimeError  # noqa: TRY301
+        except RuntimeError:
             pass
 
         assert not scratchdir.exists()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -194,3 +194,14 @@ class TestScratchDirectory:
             # Clean up the directory if it wasn't automatically removed.
             if scratchdir.is_dir():
                 shutil.rmtree(scratchdir)
+
+    def test_exception(self):
+        # Test that the scratch directory is properly cleaned up even when an exception
+        # is raised within the `with` block.
+        try:
+            with scratch_directory() as scratchdir:
+                raise RuntimeError
+        except:
+            pass
+
+        assert not scratchdir.exists()


### PR DESCRIPTION
Ensure that the scratch directory is safely deleted, even when an exception is raised during the lifetime of the context manager. Previously, when an exception was raised within the `with` block, the scratch directory cleanup step was never reached.

See https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager