### PR TITLE
check for max dimensions

### DIFF
--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -84,7 +84,7 @@ def check_dataset_sizes(
     **datasets: InputDataset | OutputDataset,
 ) -> None:
     """
-    Ensure that one or more datasets have shape that snaphu can handle.
+    Ensure that one or more datasets have shape that SNAPHU can handle.
 
     Parameters
     ----------

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-LARGESHORT = 32000
+LARGESHORT = 32000  # needs to match LARGESHORT in snaphu.h
 
 
 def check_2d_shapes(**shapes: tuple[int, ...]) -> None:
@@ -122,7 +122,11 @@ def check_dataset_sizes(
         if regrow_conncomps or single_tile_reoptimize or skip_tiling:
             # a single tile is input for snaphu
             if any(n > LARGESHORT for n in arr.shape):
-                msg = f"dataset {name} too large for SNAPHU, shape: {arr.shape}"
+                msg = (
+                    f"{name} dataset with shape {arr.shape} exceeds max dimensions"
+                    " supported by SNAPHU. Consider using tiling and disabling the"
+                    " regrow_conncomps and single_tile_reoptimize options"
+                )
                 raise ValueError(msg)
             if skip_tiling:
                 continue
@@ -135,14 +139,13 @@ def check_dataset_sizes(
         tile_height = _calc_tile_shape(arr.shape[0], ntiles[0], y_overlap)
         tile_width = _calc_tile_shape(arr.shape[1], ntiles[1], x_overlap)
         tile_shapes_max = (tile_height, tile_width)
-        for size in tile_shapes_max:
-            if size > LARGESHORT:
-                msg = (
-                    f"tile dimensions for {name} dataset are {tile_shapes_max}, which"
-                    " exceed the max supported by SNAPHU. Consider increasing number"
-                    " of tiles"
-                )
-                raise ValueError(msg)
+        if any(n > LARGESHORT for n in tile_shapes_max):
+            msg = (
+                f"tile dimensions for {name} dataset are {tile_shapes_max}, which"
+                " exceed the max supported by SNAPHU. Consider increasing number"
+                " of tiles"
+            )
+            raise ValueError(msg)
 
 
 def check_complex_dtype(**datasets: InputDataset | OutputDataset) -> None:

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -128,7 +128,7 @@ def check_dataset_sizes(
                 continue
 
         # in case tile exceeds max array size
-        def _calc_tile_shape(array_len: int, num_tiles: int, overlap_len: int):
+        def _calc_tile_shape(array_len: int, num_tiles: int, overlap_len: int) -> int:
             # tile shape calc similar to SetupTile in snaphu.c
             return math.ceil((array_len + (num_tiles - 1) * overlap_len) / num_tiles)
 

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -97,7 +97,7 @@ def check_dataset_sizes(
     single_tile_reoptimize: bool
         Whether to use single tile reoptimization after tiled unwrapping.
     **datasets : dict, optional
-        Datasets whose shape must be equal to `shape`. The name of each keyword argument
+        Datasets to be processed with SNAPHU. The name of each keyword argument
         is used to format the error message in case of a size exception.
 
     Raises

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -125,7 +125,7 @@ def check_dataset_sizes(
                 msg = f"dataset {name} too large for SNAPHU, shape: {arr.shape}"
                 raise ValueError(msg)
             if skip_tiling:
-                return
+                continue
 
         # in case tile exceeds max array size
         def _calc_tile_shape(array_len: int, num_tiles: int, overlap_len: int):

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -137,7 +137,11 @@ def check_dataset_sizes(
         tile_shapes_max = (tile_height, tile_width)
         for size in tile_shapes_max:
             if size > LARGESHORT:
-                msg = f"dataset {name} too large for snaphu, shape: {arr.shape}"
+                msg = (
+                    f"tile dimensions for {name} dataset are {tile_shapes_max}, which"
+                    " exceed the max supported by SNAPHU. Consider increasing number"
+                    " of tiles"
+                )
                 raise ValueError(msg)
 
 

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -113,7 +113,6 @@ def check_dataset_sizes(
         # cannot unpack, tile_overlap shape is checked later
         y_overlap = tile_overlap[0]
         x_overlap = tile_overlap[1]
-
     else:
         msg = f"Unknown format tile overlaps: {tile_overlap}"
         raise TypeError(msg)

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -15,6 +15,9 @@ __all__ = [
 ]
 
 
+LARGESHORT = 32000
+
+
 def check_2d_shapes(**shapes: tuple[int, ...]) -> None:
     """
     Ensure that the input tuples are valid 2-D shapes.
@@ -68,6 +71,71 @@ def check_dataset_shapes(
                 f" {name}.shape={arr.shape}"
             )
             raise ValueError(errmsg)
+
+
+def check_dataset_sizes(
+    ntiles: tuple[int, int],
+    tile_overlap: int | tuple[int, int],
+    *,
+    regrow_conncomps: bool = True,
+    single_tile_reoptimize: bool = False,
+    **datasets: InputDataset | OutputDataset,
+) -> None:
+    """
+    Ensure that one or more datasets have shape that snaphu can handle.
+
+    Parameters
+    ----------
+    ntiles : (int, int)
+        Number of tiles used in each dimension.
+    tile_overlap: int or (int, int)
+        Overlap between tiles.
+    regrow_conncomps : bool
+        Whether to regrow connected components after tiled unwrapping.
+    single_tile_reoptimize: bool
+        Whether to use single tile reoptimization after tiled unwrapping.
+    **datasets : dict, optional
+        Datasets whose shape must be equal to `shape`. The name of each keyword argument
+        is used to format the error message in case of a size exception.
+
+    Raises
+    ------
+    ValueError
+        If any dataset had a too large shape.
+    TypeError
+        If the tile overlaps type is unknown.
+    """
+    if isinstance(tile_overlap, int):
+        x_overlap = y_overlap = tile_overlap
+    elif isinstance(tile_overlap, tuple):
+        # cannot unpack, tile_overlap shape is checked later
+        x_overlap = tile_overlap[0]
+        y_overlap = tile_overlap[1]
+
+    else:
+        msg = f"Unknown format tile overlaps: {tile_overlap}"
+        raise TypeError(msg)
+
+    for name, arr in datasets.items():
+        skip_tiling: bool = ntiles == (1, 1)
+        if regrow_conncomps or single_tile_reoptimize or skip_tiling:
+            # a single tile is input for snaphu
+            for size in arr.shape:
+                if size > LARGESHORT:
+                    msg = f"dataset {name} too large for snaphu, shape: {arr.shape}"
+                    raise ValueError(msg)
+            if skip_tiling:
+                return
+
+        # in case tile exceeds max array size
+        tile_shapes_max = (
+            arr.shape[0] + 1 // ntiles[0] + x_overlap,
+            arr.shape[1] + 1 // ntiles[1] + y_overlap,
+        )
+        for size in tile_shapes_max:
+            if size > LARGESHORT:
+                msg = f"dataset {name} too large for snaphu, shape: {arr.shape}"
+                raise ValueError(msg)
 
 
 def check_complex_dtype(**datasets: InputDataset | OutputDataset) -> None:

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -121,10 +121,9 @@ def check_dataset_sizes(
         skip_tiling: bool = ntiles == (1, 1)
         if regrow_conncomps or single_tile_reoptimize or skip_tiling:
             # a single tile is input for snaphu
-            for size in arr.shape:
-                if size > LARGESHORT:
-                    msg = f"dataset {name} too large for snaphu, shape: {arr.shape}"
-                    raise ValueError(msg)
+            if any(n > LARGESHORT for n in arr.shape):
+                msg = f"dataset {name} too large for SNAPHU, shape: {arr.shape}"
+                raise ValueError(msg)
             if skip_tiling:
                 return
 

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import numpy as np
 
 from .io import InputDataset, OutputDataset
@@ -106,11 +108,11 @@ def check_dataset_sizes(
         If the tile overlaps type is unknown.
     """
     if isinstance(tile_overlap, int):
-        x_overlap = y_overlap = tile_overlap
+        y_overlap = x_overlap = tile_overlap
     elif isinstance(tile_overlap, tuple):
         # cannot unpack, tile_overlap shape is checked later
-        x_overlap = tile_overlap[0]
-        y_overlap = tile_overlap[1]
+        y_overlap = tile_overlap[0]
+        x_overlap = tile_overlap[1]
 
     else:
         msg = f"Unknown format tile overlaps: {tile_overlap}"
@@ -128,10 +130,13 @@ def check_dataset_sizes(
                 return
 
         # in case tile exceeds max array size
-        tile_shapes_max = (
-            arr.shape[0] + 1 // ntiles[0] + x_overlap,
-            arr.shape[1] + 1 // ntiles[1] + y_overlap,
-        )
+        def _calc_tile_shape(array_len: int, num_tiles: int, overlap_len: int):
+            # tile shape calc similar to SetupTile in snaphu.c
+            return math.ceil((array_len + (num_tiles - 1) * overlap_len) / num_tiles)
+
+        tile_height = _calc_tile_shape(arr.shape[0], ntiles[0], y_overlap)
+        tile_width = _calc_tile_shape(arr.shape[1], ntiles[1], x_overlap)
+        tile_shapes_max = (tile_height, tile_width)
         for size in tile_shapes_max:
             if size > LARGESHORT:
                 msg = f"dataset {name} too large for snaphu, shape: {arr.shape}"

--- a/src/snaphu/_check.py
+++ b/src/snaphu/_check.py
@@ -114,7 +114,7 @@ def check_dataset_sizes(
         y_overlap = tile_overlap[0]
         x_overlap = tile_overlap[1]
     else:
-        msg = f"Unknown format tile overlaps: {tile_overlap}"
+        msg = f"got {type(tile_overlap)=}, expected int or tuple"
         raise TypeError(msg)
 
     for name, arr in datasets.items():

--- a/src/snaphu/_unwrap.py
+++ b/src/snaphu/_unwrap.py
@@ -13,6 +13,7 @@ from ._check import (
     check_complex_dtype,
     check_cost_mode,
     check_dataset_shapes,
+    check_dataset_sizes,
     check_float_dtype,
     check_integer_dtype,
 )
@@ -331,6 +332,24 @@ def unwrap(  # type: ignore[no-untyped-def]
     ntiles, tile_overlap, nproc = normalize_and_validate_tiling_params(
         ntiles=ntiles, tile_overlap=tile_overlap, nproc=nproc
     )
+
+    # Ensure that input & output datsets are not too large
+    check_dataset_sizes(
+        ntiles,
+        tile_overlap,
+        regrow_conncomps=regrow_conncomps,
+        single_tile_reoptimize=single_tile_reoptimize,
+        unw=unw,
+        conncomp=conncomp,
+    )
+    if mask is not None:
+        check_dataset_sizes(
+            ntiles,
+            tile_overlap,
+            regrow_conncomps=regrow_conncomps,
+            single_tile_reoptimize=single_tile_reoptimize,
+            mask=mask,
+        )
 
     with scratch_directory(scratchdir, delete=delete_scratch) as dir_:
         # Create a raw binary file in the scratch directory for the interferogram and

--- a/src/snaphu/_unwrap.py
+++ b/src/snaphu/_unwrap.py
@@ -333,23 +333,14 @@ def unwrap(  # type: ignore[no-untyped-def]
         ntiles=ntiles, tile_overlap=tile_overlap, nproc=nproc
     )
 
-    # Ensure that input & output datsets are not too large
+    # Ensure that the dataset (and tile) dimensions are not too large.
     check_dataset_sizes(
         ntiles,
         tile_overlap,
         regrow_conncomps=regrow_conncomps,
         single_tile_reoptimize=single_tile_reoptimize,
-        unw=unw,
-        conncomp=conncomp,
+        igram=igram,
     )
-    if mask is not None:
-        check_dataset_sizes(
-            ntiles,
-            tile_overlap,
-            regrow_conncomps=regrow_conncomps,
-            single_tile_reoptimize=single_tile_reoptimize,
-            mask=mask,
-        )
 
     with scratch_directory(scratchdir, delete=delete_scratch) as dir_:
         # Create a raw binary file in the scratch directory for the interferogram and

--- a/test/test_unwrap.py
+++ b/test/test_unwrap.py
@@ -223,11 +223,11 @@ class TestUnwrap:
         igram = MagicMock(spec=np.ndarray)
         igram.shape = arr_shape
         igram.ndim = 2
-        igram.dtype = np.dtypes.Complex64DType()
+        igram.dtype = np.complex64
         corr = MagicMock(spec=np.ndarray)
         corr.shape = arr_shape
         corr.ndim = 2
-        corr.dtype = np.dtypes.Float32DType()
+        corr.dtype = np.float32
         with pytest.raises(ValueError, match=err_msg):
             snaphu.unwrap(igram, corr, nlooks=1.0, **kwargs)
 

--- a/test/test_unwrap.py
+++ b/test/test_unwrap.py
@@ -194,16 +194,20 @@ class TestUnwrap:
                 (32001, 128),
                 {"regrow_conncomps": False},
             ),
-            (  # tiling will work, but regrowing too large
-                (32001, 128),
-                {"ntiles": (2, 2), "tile_overlap": (64, 64), "regrow_conncomps": True},
+            (  # no regrowing, but tile 1 pixel too large
+                (63937, 128),
+                {
+                    "ntiles": (2, 2),
+                    "tile_overlap": (64, 64),
+                    "regrow_conncomps": False,
+                },
             ),
-            (  # tile overlaps too large
+            (  # regrow on, single_tile too large due to overlap
                 (128, 128),
                 {
                     "ntiles": (2, 2),
-                    "tile_overlap": (32001, 32001),
-                    "regrow_conncomps": True,
+                    "tile_overlap": (63873, 64),
+                    "single_tile_reoptimize": True,
                 },
             ),
         ],

--- a/test/test_unwrap.py
+++ b/test/test_unwrap.py
@@ -188,11 +188,13 @@ class TestUnwrap:
         (
             "arr_shape",
             "kwargs",
+            "err_msg",
         ),
         [
             (  # conncomps not on, but still too large
                 (32001, 128),
                 {"regrow_conncomps": False},
+                r"igram dataset with shape \(32001, 128\) exceeds max dimensions",
             ),
             (  # no regrowing, but tile 1 pixel too large
                 (63937, 128),
@@ -200,7 +202,9 @@ class TestUnwrap:
                     "ntiles": (2, 2),
                     "tile_overlap": (64, 64),
                     "regrow_conncomps": False,
+                    "single_tile_reoptimize": False,
                 },
+                r"tile dimensions for igram dataset are \(32001, 96\)",
             ),
             (  # regrow on, single_tile too large due to overlap
                 (128, 128),
@@ -209,10 +213,13 @@ class TestUnwrap:
                     "tile_overlap": (63873, 64),
                     "single_tile_reoptimize": True,
                 },
+                r"tile dimensions for igram dataset are \(32001, 96\)",
             ),
         ],
     )
-    def test_shape_too_large(self, arr_shape: tuple[int, int], kwargs: dict[str, Any]):
+    def test_shape_too_large(
+        self, arr_shape: tuple[int, int], kwargs: dict[str, Any], err_msg: str
+    ):
         igram = MagicMock(spec=np.ndarray)
         igram.shape = arr_shape
         igram.ndim = 2
@@ -221,8 +228,7 @@ class TestUnwrap:
         corr.shape = arr_shape
         corr.ndim = 2
         corr.dtype = np.dtypes.Float32DType()
-        pattern = r"too large for snaphu"
-        with pytest.raises(ValueError, match=pattern):
+        with pytest.raises(ValueError, match=err_msg):
             snaphu.unwrap(igram, corr, nlooks=1.0, **kwargs)
 
     def test_bad_igram_dtype(self):

--- a/test/test_unwrap.py
+++ b/test/test_unwrap.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -182,6 +183,43 @@ class TestUnwrap:
         )
         with pytest.raises(ValueError, match=pattern):
             snaphu.unwrap(igram, corr, nlooks=100.0)
+
+    @pytest.mark.parametrize(
+        (
+            "arr_shape",
+            "kwargs",
+        ),
+        [
+            (  # conncomps not on, but still too large
+                (32001, 128),
+                {"regrow_conncomps": False},
+            ),
+            (  # tiling will work, but regrowing too large
+                (32001, 128),
+                {"ntiles": (2, 2), "tile_overlap": (64, 64), "regrow_conncomps": True},
+            ),
+            (  # tile overlaps too large
+                (128, 128),
+                {
+                    "ntiles": (2, 2),
+                    "tile_overlap": (32001, 32001),
+                    "regrow_conncomps": True,
+                },
+            ),
+        ],
+    )
+    def test_shape_too_large(self, arr_shape: tuple[int, int], kwargs: dict[str, Any]):
+        igram = MagicMock(spec=np.ndarray)
+        igram.shape = arr_shape
+        igram.ndim = 2
+        igram.dtype = np.dtypes.Complex64DType()
+        corr = MagicMock(spec=np.ndarray)
+        corr.shape = arr_shape
+        corr.ndim = 2
+        corr.dtype = np.dtypes.Float32DType()
+        pattern = r"too large for snaphu"
+        with pytest.raises(ValueError, match=pattern):
+            snaphu.unwrap(igram, corr, nlooks=1.0, **kwargs)
 
     def test_bad_igram_dtype(self):
         shape = (128, 128)


### PR DESCRIPTION
Fixes #111 .
Tests use `unittest.mock.MagicMock` to avoid creating large arrays during testing.